### PR TITLE
Update national/international hotline phone numbers (closes #12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,14 @@
 <a href="https://github.com/corona-warn-app/cwa-hotline/issues" title="Open Issues"><img src="https://img.shields.io/github/issues/corona-warn-app/cwa-hotline"></a>
 
 ## About this Repository
-This repository contains all issues that need to be addressed to the hotlines of the Corona-Warn-App, i.e. +498007540001 (app & technical questions) and +498007540002 (TAN requests). This is **not** a standard development repository! 
+This repository contains all issues that need to be addressed regarding the hotlines of the Corona-Warn-App. The App hotline is for technical questions regarding the Corona-Warn-App. The TAN hotline serves requests to issue TANs for the Corona-Warn-App. The national telephone number is to be used when calling from within Germany. The international number is available for calls originating outside Germany.
+
+Hotline | App | TAN
+--- | --- | ---
+National | [0800 7540001](tel:08007540001) | [0800 7540002](tel:08007540002)
+International | [+49 30 498 75401](tel:+493049875401) | [+49 30 498 75402](tel:+493049875402)
+
+This is **not** a standard development repository!
 
 ## How to check or raise issues
 Simply see the [issue section](https://github.com/corona-warn-app/cwa-hotline/issues) and check if the issue you want to raise was already reported. Feel free [to raise a new issue](https://github.com/corona-warn-app/cwa-hotline/issues/new/choose) in case yours hasn't been reported yet. Please use one of our issue templates so that we can ensure that all necessary information is already there.
@@ -15,9 +22,9 @@ Issues which are opened and do not contain a valid request to the hotline will b
 
 ## Licensing
 
-Copyright (c) 2020 Deutsche Telekom AG and SAP SE or an SAP affiliate company.
+Copyright (c) 2020-2021 Deutsche Telekom AG and SAP SE or an SAP affiliate company.
 
-Licensed under the **Apache License, Version 2.0** (the "License"); you may not use this file except in compliance with the License. 
+Licensed under the **Apache License, Version 2.0** (the "License"); you may not use this file except in compliance with the License.
 
 You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.
 


### PR DESCRIPTION
This PR updates the [README.md](https://github.com/corona-warn-app/cwa-hotline/blob/master/README.md) with the current hotline phone numbers as shown on https://www.coronawarn.app/en/ . It resolves the issue #12.

![image](https://user-images.githubusercontent.com/66998419/121487267-36860500-c9d2-11eb-8582-82e86e59f9ce.png)

This information has been added to [README.md](https://github.com/corona-warn-app/cwa-hotline/blob/master/README.md) in the form of a table:

Hotline | App | TAN
--- | --- | ---
National | [0800 7540001](tel:08007540001) | [0800 7540002](tel:08007540002)
International | [+49 30 498 75401](tel:+493049875401) | [+49 30 498 75402](tel:+493049875402).

The new numbers were introduced in March 2021 - see https://github.com/corona-warn-app/cwa-documentation/issues/502#issuecomment-800893642.

---
Additional incidental changes:
- I updated the copyright to 2020-2021
- I removed some trailing spaces at the end of lines