### PR TITLE
Add cross-reference for app and TAN hotline operating hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <a href="https://github.com/corona-warn-app/cwa-hotline/issues" title="Open Issues"><img src="https://img.shields.io/github/issues/corona-warn-app/cwa-hotline"></a>
 
 ## About this Repository
-This repository contains all issues that need to be addressed regarding the hotlines of the Corona-Warn-App. The App hotline is for technical questions regarding the Corona-Warn-App. The TAN hotline serves requests to issue TANs for the Corona-Warn-App. The national telephone number is to be used when calling from within Germany. The international number is available for calls originating outside Germany.
+This repository contains all issues that need to be addressed regarding the hotlines of the Corona-Warn-App. The App hotline is for technical questions regarding the Corona-Warn-App. The TAN hotline serves requests to issue TANs for the Corona-Warn-App. The national telephone number is to be used when calling from within Germany. The international number is available for calls originating outside Germany. The operating hours of the app and TAN hotlines are listed in the [Support](https://www.coronawarn.app/en/faq/#support) section of the [Corona-Warn-App website](https://www.coronawarn.app/).
 
 Hotline | App | TAN
 --- | --- | ---
@@ -22,7 +22,7 @@ Issues which are opened and do not contain a valid request to the hotline will b
 
 ## Licensing
 
-Copyright (c) 2020-2021 Deutsche Telekom AG and SAP SE or an SAP affiliate company.
+Copyright (c) 2020-2022 Deutsche Telekom AG and SAP SE or an SAP affiliate company.
 
 Licensed under the **Apache License, Version 2.0** (the "License"); you may not use this file except in compliance with the License.
 


### PR DESCRIPTION
This PR adds a cross-reference from this hotline repository to the external website https://www.coronawarn.app/ regarding the operating hours of the hotlines. The following sentence is added to the README file:

"The operating hours of the app and TAN hotlines are listed in the [Support](https://www.coronawarn.app/en/faq/#support) section of the [Corona-Warn-App website](https://www.coronawarn.app/)."

So that the operating hours do not have to be maintained in multiple places, the above does not list the hours literally, it only provides a cross-reference to https://www.coronawarn.app/en/faq/#support.

## Current / planned changes to operating hours

- ~~The current operating hours of the App hotline are Monday to Saturday from 7 a.m. to 10 p.m.~~
- According to issue https://github.com/corona-warn-app/cwa-website/issues/2294 the TAN hotline changed its operating hours on Jan 16, 2022 to Monday to Sunday from 7 a.m. to 8 p.m.