### PR TITLE
Bump copyright year in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Issues which are opened and do not contain a valid request to the hotline will b
 
 ## Licensing
 
-Copyright (c) 2020-2022 Deutsche Telekom AG and SAP SE or an SAP affiliate company.
+Copyright (c) 2020-2023 Deutsche Telekom AG and SAP SE or an SAP affiliate company.
 
 Licensed under the **Apache License, Version 2.0** (the "License"); you may not use this file except in compliance with the License.
 


### PR DESCRIPTION
## Description

This PR bumps the copyright year in the README.md file.

Happy new year! 🎉

### Note

This PR should only be merged once a change to any content of this repository was done.

---
Internal Tracking ID: [EXPOSUREAPP-14521](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14521)